### PR TITLE
MonoInject and Instantiate overrides for IContainer

### DIFF
--- a/Assets/Reflex/Scripts/Core/IContainer.cs
+++ b/Assets/Reflex/Scripts/Core/IContainer.cs
@@ -6,7 +6,10 @@ namespace Reflex.Scripts
     public interface IContainer : IDisposable
     {
         public void AddDisposable(IDisposable disposable);
-        public T Instantiate<T>(T original) where T : Component;
+        public MonoBehaviour InjectMono(MonoBehaviour instance, bool recursive = false);
+        public T Instantiate<T>(T original, Transform container = null) where T : Component;
+        public T Instantiate<T>(T original, Transform container, bool worldPositionStays) where T : Component;
+        public T Instantiate<T>(T original, Vector3 position, Quaternion rotation, Transform container = null) where T : Component;
         public GameObject Instantiate(GameObject original);
         public T Construct<T>();
         public object Construct(Type concrete);

--- a/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs
+++ b/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Reflex.Injectors;
+using UnityEngine;
+
+namespace Reflex.Scripts.Utilities
+{
+    internal class MonoInstantiate
+    {
+        private static Transform _hiddenParent;
+
+        private static Transform HiddenParent
+        {
+            get
+            {
+                if (_hiddenParent == null)
+                {
+                    var gameObject = new GameObject("[Reflex] Hidden Parent");
+                    gameObject.SetActive(false);
+                    _hiddenParent = gameObject.transform;
+                }
+
+                return _hiddenParent;
+            }
+        }
+
+        internal static void InjectMonoBehaviour<T>(T instance, IContainer container) where T : Component
+        {
+            instance.GetComponentsInChildren<MonoBehaviour>().ForEach(mb => MonoInjector.Inject(mb, container));
+        }
+
+        internal static T Instantiate<T>(T original, Transform root, IContainer container, Func<Transform, T> instantiate) where T : Component
+        {
+            var parent = root;
+            var prefabWasActive = original.gameObject.activeSelf;
+
+            if (prefabWasActive)
+                parent = HiddenParent;
+
+            var instance = instantiate.Invoke(parent);
+
+            if (prefabWasActive)
+                instance.gameObject.SetActive(false);
+
+            if (instance.transform.parent != root)
+                instance.transform.SetParent(root, false);
+
+            InjectMonoBehaviour(instance, container);
+
+            instance.gameObject.SetActive(prefabWasActive);
+
+            return instance;
+        }
+    }
+}

--- a/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs.meta
+++ b/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d11b805f57294b499f672bbf33eb9d79
+timeCreated: 1662736176


### PR DESCRIPTION
# MonoInject and Instantiate overrides for IContainer

## IContainer.Instantiate overrides
 For best compatibility with Unity Object.Instantiate added several overrides for IContainer.
 ```c#
 public T Instantiate<T>(T original, Transform container = null) where T : Component;
 public T Instantiate<T>(T original, Transform container, bool worldPositionStays) where T : Component;
 public T Instantiate<T>(T original, Vector3 position, Quaternion rotation, Transform container = null) where T : Component;
 ```
 ## IContainer.MonoInject method
 Recursive and solo MonoInject for any custom MonoBehaviour
  ```c#
public MonoBehaviour InjectMono(MonoBehaviour instance, bool recursive = false);
 ```
 ## MonoInjection BEFORE Awake and OnEnable
 When you use old IContainer.Instantiate method all injections called after Awake and OnEnable, but SceneContext trigger Injections before call Awake and OnEnable. Make same behaviour
 See: MonoInstantiate.Instantiate
