### PR TITLE
Add MonoInject and Instantiate overrides for Container

### DIFF
--- a/Assets/Reflex/Scripts/Core/Container.cs
+++ b/Assets/Reflex/Scripts/Core/Container.cs
@@ -115,11 +115,24 @@ namespace Reflex
             throw new UnknownContractException(contract);
         }
         
-        public T Instantiate<T>(T original, Transform parent = null, MonoInjectionMode injectionMode = MonoInjectionMode.Recursive) where T : Component
+        public void InjectMono(Component instance, MonoInjectionMode injectionMode = MonoInjectionMode.Single)
         {
-            var instance = UnityEngine.Object.Instantiate<T>(original, parent);
             instance.GetInjectables(injectionMode).ForEach(mb => MonoInjector.Inject(mb, this));
-            return instance;
+        }
+
+        public T Instantiate<T>(T original, Transform container = null, MonoInjectionMode injectionMode = MonoInjectionMode.Recursive) where T : Component
+        {
+            return MonoInstantiate.Instantiate(original, container, this, (parent) => UnityEngine.Object.Instantiate<T>(original, parent), injectionMode);
+        }
+
+        public T Instantiate<T>(T original, Transform container, bool worldPositionStays, MonoInjectionMode injectionMode = MonoInjectionMode.Recursive) where T : Component
+        {
+            return MonoInstantiate.Instantiate(original, container, this, (parent) => UnityEngine.Object.Instantiate<T>(original, parent, worldPositionStays), injectionMode);
+        }
+
+        public T Instantiate<T>(T original, Vector3 position, Quaternion rotation, Transform container = null, MonoInjectionMode injectionMode = MonoInjectionMode.Recursive) where T : Component
+        {
+            return MonoInstantiate.Instantiate(original, container, this, (parent) => UnityEngine.Object.Instantiate<T>(original, position, rotation, parent), injectionMode);
         }
     }
 }

--- a/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs
+++ b/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Reflex.Injectors;
+using Reflex.Scripts.Enums;
+using Reflex.Scripts.Extensions;
+using UnityEngine;
+
+namespace Reflex.Scripts.Utilities
+{
+    internal class MonoInstantiate
+    {
+        private static Transform _hiddenParent;
+
+        private static Transform HiddenParent
+        {
+            get
+            {
+                if (_hiddenParent == null)
+                {
+                    var gameObject = new GameObject("[Reflex] Hidden Parent");
+                    gameObject.SetActive(false);
+                    _hiddenParent = gameObject.transform;
+                }
+
+                return _hiddenParent;
+            }
+        }
+
+        internal static T Instantiate<T>(T original, Transform parent, Container container, Func<Transform, T> instantiate, MonoInjectionMode injectionMode) where T : Component
+        {
+            var root = parent;
+            var prefabWasActive = original.gameObject.activeSelf;
+
+            if (prefabWasActive)
+                root = HiddenParent;
+
+            var instance = instantiate.Invoke(root);
+
+            if (prefabWasActive)
+                instance.gameObject.SetActive(false);
+
+            if (instance.transform.parent != parent)
+                instance.transform.SetParent(parent, false);
+
+            instance.GetInjectables(injectionMode).ForEach(mb => MonoInjector.Inject(mb, container));
+
+            instance.gameObject.SetActive(prefabWasActive);
+
+            return instance;
+        }
+    }
+}

--- a/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs
+++ b/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Reflex.Scripts.Utilities
 {
-    internal class MonoInstantiate
+    internal static class MonoInstantiate
     {
         private static Transform _hiddenParent;
 
@@ -43,9 +43,22 @@ namespace Reflex.Scripts.Utilities
 
             instance.GetInjectables(injectionMode).ForEach(mb => MonoInjector.Inject(mb, container));
 
+            instance.gameObject.RestoreRectTransform(original);
             instance.gameObject.SetActive(prefabWasActive);
 
             return instance;
+        }
+
+        internal static void RestoreRectTransform(this GameObject gameObject, Component original)
+        {
+            if (gameObject.TryGetComponent<RectTransform>(out var rectTransform) && original.TryGetComponent<RectTransform>(out var originalRectTransform))
+            {
+                rectTransform.offsetMax = originalRectTransform.offsetMax;
+                rectTransform.offsetMin = originalRectTransform.offsetMin;
+                rectTransform.anchorMax = originalRectTransform.anchorMax;
+                rectTransform.anchorMin = originalRectTransform.anchorMin;
+                rectTransform.localScale = originalRectTransform.localScale;
+            }
         }
     }
 }

--- a/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs.meta
+++ b/Assets/Reflex/Scripts/Utilities/MonoInstantiate.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d11b805f57294b499f672bbf33eb9d79
+timeCreated: 1662736176


### PR DESCRIPTION
Update order of execution for runtime instantiated MonoBehaviour.
For best compatibility with Unity Object.Instantiate added several overrides for Container.
InjectMono as public method for any custom MonoBehaviour

It`s update prevision closed [pull request #13](https://github.com/gustavopsantos/Reflex/pull/13) 