### PR TITLE
Update UnityInjector.cs

### DIFF
--- a/Assets/Reflex/Injectors/UnityInjector.cs
+++ b/Assets/Reflex/Injectors/UnityInjector.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Scripting;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 [assembly: AlwaysLinkAssembly] // https://docs.unity3d.com/ScriptReference/Scripting.AlwaysLinkAssemblyAttribute.html
 
 namespace Reflex.Injectors
@@ -49,6 +53,14 @@ namespace Reflex.Injectors
                 SceneManager.sceneUnloaded -= DisposeScene;
                 Application.quitting -= DisposeProject;
             }
+            
+#if UNITY_EDITOR
+            // if Enter Play Mode Option Checked
+            if (EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                InjectScene(SceneManager.GetActiveScene(), LoadSceneMode.Single);
+            }
+#endif
 
             SceneManager.sceneLoaded += InjectScene;
             SceneManager.sceneUnloaded += DisposeScene;


### PR DESCRIPTION
fix bug if Unity EnterPlayMode Options Checked in Editor

if we checked EnterPlayMode Option in ProjectSetting > Editor > Enter Play Mode Option, after play in Editor SceneManager.sceneLoaded will not invoked
