### PR TITLE
Auto Scene Inject For Runtime Objects

### DIFF
--- a/Assets/Reflex/Components.meta
+++ b/Assets/Reflex/Components.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70765ba118cb33841bbb18a633dfac93
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Reflex/Components/AutoSceneInjectComponent.cs
+++ b/Assets/Reflex/Components/AutoSceneInjectComponent.cs
@@ -1,0 +1,39 @@
+using Reflex.Extensions;
+using Reflex.Injectors;
+using UnityEngine;
+
+namespace Reflex.Components
+{
+    [DefaultExecutionOrder(int.MinValue + 1)]
+    public sealed class AutoSceneInjectComponent : MonoBehaviour
+    {
+        [SerializeField] private InjectType _injectType = InjectType.Object;
+        
+        private void Awake()
+        {
+            var sceneContainer = gameObject.scene.GetSceneContainer();
+
+            switch (_injectType)
+            {
+                case InjectType.Single:
+                    GameObjectInjector.InjectSingle(gameObject, sceneContainer);
+                    break;
+                case InjectType.Object:
+                    GameObjectInjector.InjectObject(gameObject, sceneContainer);
+                    break;
+                case InjectType.Recursive:
+                    GameObjectInjector.InjectRecursive(gameObject, sceneContainer);
+                    break;
+            }
+       }
+
+        private enum InjectType
+        {
+            Single,
+            Object,
+            Recursive
+        }
+    }
+
+    
+}

--- a/Assets/Reflex/Components/AutoSceneInjectComponent.cs.meta
+++ b/Assets/Reflex/Components/AutoSceneInjectComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20620ae30fdd0164c9bb5bdc717d3ada
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -416,6 +416,10 @@ GameObjectInjector::void InjectRecursiveMany(List<GameObject> gameObject, Contai
 // Optimized code meant to find injectables (MonoBehaviours) from a given GameObject, to then, inject using AttributeInjector
 // This option injects all MonoBehaviours found on the given list of GameObject and its childrens recursively 
 ```
+### Components
+Currently there is AutoSceneInjectComponent, which you can attach to a prefab for resolving its dependencies at runtime.
+From component you can select which type of injection you can select: Single, Object, and Recursive. It calls corresponding
+GameObjectInjector method.
 
 ---
 


### PR DESCRIPTION
# Pull Request Template

## Description

Even though not core or crucial, I believe it is a useful utility component.

Might be me not managing my dependencies careful enough but I find myself in need of injection for dynamically created gameobjects/MBs at runtime a bit often.

Similar to ZenAutoInjecter, I added a component for gameobject injection, which calls according GameObjectInjector method for given object. Just adding them to the gameobject/prefab does the job.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tried to create a runtime object in a scene with/without a SceneScope. SceneScope scene object is able to get its dependencies at runtime, Non SceneScope scene dependencies throws null ref for missing SceneScope,  which is expected.
I first thought adding TryGetScene extension for this, but even bypassing here, it would throw null ref for dependencies right after, so I though better of it not.

**Test Configuration**: 
Unity 2021.3.39f1

