### PR TITLE
Fixes Hierarchy column contents overflowing in the Reflex Debugger

### DIFF
--- a/Assets/Reflex/Editor/DebuggingWindow/MultiColumnTreeView.cs
+++ b/Assets/Reflex/Editor/DebuggingWindow/MultiColumnTreeView.cs
@@ -71,7 +71,7 @@ namespace Reflex.Editor.DebuggingWindow
                     {
                         DrawName(item, cellRect, item.Data.Name);
                     }
-                    
+
                     break;
                 case Column.Calls:
                     GUI.Label(cellRect, item.Data.Resolutions.Invoke());
@@ -108,23 +108,44 @@ namespace Reflex.Editor.DebuggingWindow
                 fontStyle = FontStyle.Bold,
                 fontSize = 11
             };
-            
+
             rect.xMin += GetContentIndent(item);
 
-            foreach (var contract in contracts)
+            // Clipping group
+            GUI.BeginGroup(rect);
             {
-                var content = new GUIContent($"{contract}");
-                rect.width = style.CalcSize(content).x;
-                GUI.Label(rect, content, style);
-                rect.xMin += rect.width + 4;
+                foreach (var contract in contracts)
+                {
+                    var content = new GUIContent($"{contract}");
+                    var labelWidth = style.CalcSize(content).x;
+
+                    // Draw the label within the bounds of the rect
+                    Rect labelRect = new Rect(0, 0, labelWidth, rect.height);
+                    GUI.Label(labelRect, content, style);
+
+                    // Move the rect for the next contract
+                    rect.xMin += labelWidth + 4;
+
+                    // Stop drawing if the labels go beyond the column's width
+                    if (rect.xMin > rect.width)
+                        break;
+                }
             }
+            GUI.EndGroup();
         }
 
         private void DrawItemIcon(Rect area, TreeViewItem<MyTreeElement> item)
         {
             area.xMin += GetContentIndent(item);
-            area.width = 16;
-            GUI.DrawTexture(area, item.Data.Icon, ScaleMode.ScaleToFit);
+
+            // Clipping group
+            GUI.BeginGroup(area);
+            {
+                // Draw the icon within the bounds of the area
+                Rect iconRect = new Rect(0, 0, 16, area.height);
+                GUI.DrawTexture(iconRect, item.Data.Icon, ScaleMode.ScaleToFit);
+            }
+            GUI.EndGroup();
         }
 
         private void DrawItemNameColumn(Rect area, TreeViewItem<MyTreeElement> item, ref RowGUIArgs args)


### PR DESCRIPTION
Fixes overflow of column contents with [`GUI.BeginGroup`](https://docs.unity3d.com/ScriptReference/GUI.BeginGroup.html). Which is most noticeable when a lot of contracts are specified.

Issue:
![before](https://github.com/user-attachments/assets/37f0e331-2a0e-4ed2-b5f4-1922a616e6b5)

After fix:
![after](https://github.com/user-attachments/assets/f6a45a01-5c13-4a8a-bd6d-42a3e8ca9ba3)
