### PR TITLE
Fix warnings in Unity 6 (#62)

### DIFF
--- a/Assets/Reflex/Editor/DebuggingWindow/UnityScriptingDefineSymbols.cs
+++ b/Assets/Reflex/Editor/DebuggingWindow/UnityScriptingDefineSymbols.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.Build;
 
 public static class UnityScriptingDefineSymbols
 {
@@ -26,12 +27,12 @@ public static class UnityScriptingDefineSymbols
     
     private static HashSet<string> GetSymbols(BuildTargetGroup platform)
     {
-        return new HashSet<string>(PlayerSettings.GetScriptingDefineSymbolsForGroup(platform).Split(';'));
+        return new HashSet<string>(PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(platform)).Split(';'));
     }
     
     private static void SetSymbols(HashSet<string> symbols, BuildTargetGroup platform)
     {
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(platform, string.Join(";", symbols));
+        PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(platform), string.Join(";", symbols));
     }
 
     public static void Toggle(string symbol, BuildTargetGroup platform)


### PR DESCRIPTION
## Description

Fixes #62

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- No more compilation warnings in Unity 6000.0.17f1
- In repo project still open and compile without errors in Unity 2021.3.21f1