### PR TITLE
Provide alternative to Resources.LoadAll when creating container

### DIFF
--- a/Assets/Reflex/Configuration/ReflexSettings.cs
+++ b/Assets/Reflex/Configuration/ReflexSettings.cs
@@ -1,4 +1,4 @@
-﻿using Reflex.Logging;
+using Reflex.Logging;
 using UnityEngine;
 
 namespace Reflex.Configuration
@@ -6,10 +6,16 @@ namespace Reflex.Configuration
     internal sealed class ReflexSettings : ScriptableObject
     {
         [field: SerializeField] public LogLevel LogLevel { get; private set; }
+        [field: SerializeField] public bool LoadAllProjectScopes { get; private set; }
 
         private void OnValidate()
         {
             ReflexLogger.UpdateLogLevel(LogLevel);
+        }
+
+        private void Reset()
+        {
+            LoadAllProjectScopes = true;
         }
     }
 }

--- a/Assets/Reflex/Core/CreateProjectContainer.cs
+++ b/Assets/Reflex/Core/CreateProjectContainer.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using Reflex.Configuration;
 using UnityEngine;
 
 namespace Reflex.Core
@@ -7,9 +10,16 @@ namespace Reflex.Core
     {
         public static Container Create()
         {
+            var reflexSettings = Resources.Load<ReflexSettings>(nameof(ReflexSettings));
+
+            var loadAllProjectScopes = reflexSettings != null
+                ? reflexSettings.LoadAllProjectScopes
+                : true;
+
             var builder = new ContainerBuilder().SetName("ProjectContainer");
-            var projectScopes = Resources.LoadAll<ProjectScope>(string.Empty);
-            var activeProjectScopes = projectScopes.Where(s => s.gameObject.activeSelf);
+            var activeProjectScopes = loadAllProjectScopes
+                ? LoadAllProjectScopes()
+                : LoadSingleProjectScope();
 
             foreach (var projectScope in activeProjectScopes)
             {
@@ -17,6 +27,22 @@ namespace Reflex.Core
             }
 
             return builder.Build();
+        }
+
+        private static IEnumerable<ProjectScope> LoadAllProjectScopes()
+        {
+            var projectScopes = Resources.LoadAll<ProjectScope>(string.Empty);
+            var activeProjectScopes = projectScopes;
+            return activeProjectScopes;
+        }
+
+        private static IEnumerable<ProjectScope> LoadSingleProjectScope()
+        {
+            var projectScope = Resources.Load<ProjectScope>("ProjectScope");
+            if (projectScope != null && projectScope.gameObject.activeSelf)
+            {
+                yield return projectScope;
+            }
         }
     }
 }

--- a/Assets/Resources/ReflexSettings.asset
+++ b/Assets/Resources/ReflexSettings.asset
@@ -13,3 +13,4 @@ MonoBehaviour:
   m_Name: ReflexSettings
   m_EditorClassIdentifier: 
   <LogLevel>k__BackingField: -1
+  <LoadAllProjectScopes>k__BackingField: 1

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ Note that ProjectScope prefab is not required, in case Reflex does not find any 
 ProjectScope instance will be disposed once app closes/app quits.
 > Note that unity does not call OnDestroy deterministically, so rule of thumb is do not rely on injected dependencies on OnDestroy event functions.
 
+> Note that you can use `LoadAllProjectScopes` setting in `ReflexSettings` to restrict loading only one ProjectScope that sits at `Resources/ProjectScope.prefab`.
+
 ### Scene Scope
 It is scoped from ProjectScope, inheriting all bindings from ProjectScope.
 It is created and injected before Awake. 


### PR DESCRIPTION
## Description

This keeps the default behavior but provides an option to minimize start-up impact and potential exceptions at runtime.
In our project using `Resources.LoadAll<T>` forces evaluation of all resource assets. 
This, in turn, can generate the following exception:

> A scripted object (script unknown or not yet loaded) has a different serialization layout when loading. (Read 56 bytes but expected 444 bytes)
>Did you #if UNITY_EDITOR a section of your serialized properties in any of your scripts?

Granted, this exception might not be caused by the `Resources.LoadAll<T>` call but I would like the option of loading only a certain `ProjectScope`.

Fixes # (issue)
None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested the issue does not reproduce with this define in our internal project

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have checked that Reflex.GettingStarted still runs nicely
