### PR TITLE
Update README.md to further clarify the need of a scene scope when us…

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,11 @@ public class Loader : MonoBehaviour
 ---
 
 ## 🎯 Injection Strategy
-Beginning from version 8.0.0, Reflex stops injecting all scenes automatically on Start, to start injecting only scenes with a SceneScope on Awake.
-This allows users to consume injected dependencies on callbacks such as Awake and OnEnable while giving more granular control on which scenes must be injected or not.
+As of version 8.0.0 Reflex has stopped automatically managing dependency injection for any scene.
+
+If you plan on using dependency injection in one of your scenes, add a game object somewhere in the hierarchy with a `SceneScope` component attached. You can still manage dependencies project-wide or utilize this scene container for limited access. This component must be present at scene load time.
+
+This allows users to consume injected dependencies on callbacks such as `Awake` and `OnEnable` while giving more granular control over which scene should be injected or not.
 
 ---
 


### PR DESCRIPTION
## Description

I wanted to use runtime injection because of network spawning a player object. Since version 8.0.0 a `SceneScope` is required to start injection. When one misses this component addition and uses a `GameObjectSelfInjector` a dictionary based error will be raised.

`KeyNotFoundException: The given key 'UnityEngine.SceneManagement.Scene' was not present in the dictionary.
(at ./Library/PackageCache/com.gustavopsantos.reflex@5f1978867817/Extensions/SceneExtensions.cs:11)`

This PR should be more speficic about runtime instantiation and the need of having a `SceneScope` attached.

Further description about my error description can be read in the discord support topic: https://discordapp.com/channels/1098008290052546731/1360327814171328532

Fixes # (issue)

- [x] This change updated a topic within the readme

## How Has This Been Tested?

Since I do not have changed any code, I did not test my changes.

## Checklist:

- [x] I did not use any AI assistance for my changes
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
- [ ] I have checked that Reflex.GettingStarted still runs nicely