### PR TITLE
Null check before dispose `ProjectContainer`

### DIFF
--- a/Assets/Reflex/Injectors/UnityInjector.cs
+++ b/Assets/Reflex/Injectors/UnityInjector.cs
@@ -48,7 +48,7 @@ namespace Reflex.Injectors
             
             void DisposeProject()
             {
-                ProjectContainer.Dispose();
+                ProjectContainer?.Dispose();
                 ProjectContainer = null;
                 
                 // Unsubscribe from static events ensuring that Reflex works with domain reloading set to false


### PR DESCRIPTION
# Pull Request Template

## Description

It seems there are cases when ProjectContainer is null due to some exception during container build stage. So quitting play mode cause call `ProjectContainer.Dispose` on null. `ProjectContainer?.Dispose` simply check for null before call method, which prevent such exceptions.

Fixes # (issue)

In some cases after exiting play mode we get NullRefernceException due to null ProjectContainer

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

After code change I've run unit tests and also Reflex.Sample scene. All goes fine.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have checked that Reflex.GettingStarted still runs nicely (I believe it is now called `Reflex.Sample`)
