### PR TITLE
Switch ReflexSettings to async resource loading

### DIFF
--- a/Assets/Reflex/Configuration/ReflexSettings.cs
+++ b/Assets/Reflex/Configuration/ReflexSettings.cs
@@ -9,14 +9,17 @@ namespace Reflex.Configuration
     internal sealed class ReflexSettings : ScriptableObject
     {
         private static ReflexSettings _instance;
-        
+        private static ResourceRequest _settingsRequest;
+
         public static ReflexSettings Instance
         {
             get
             {
                 if (_instance == null)
                 {
-                    _instance = Resources.Load<ReflexSettings>("ReflexSettings");
+                    // This stalls execution until the request fully resolves.
+                    // This *should* be faster than non-async loading when project installers have a lot of references.
+                    _instance = (ReflexSettings)_settingsRequest.asset;
                 }
                 
                 Assert.IsNotNull(_instance, "ReflexSettings not found in Resources folder.\n" +
@@ -32,6 +35,12 @@ namespace Reflex.Configuration
         {
             _instance = this;
             ReflexLogger.UpdateLogLevel(LogLevel);
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        public static void InitializeReflex()
+        {
+            _settingsRequest = Resources.LoadAsync<ReflexSettings>("ReflexSettings");
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This change switches ReflexSettings to load reflex settings via async resources load, vs the current non-async option.

This change means that reflex settings, together with all its references, are loaded into memory immediately upon game load, rather than during Awake of the first scene which has a SceneScope.

This change shouldn't change anything meaninfully for projects, for which project installers do not have many references. It should increase initialization times for projects where loading ReflexSettings via resources takes a long time (I've noticed it particularly on low-end mobile platforms).

It has the slight drawback of potentially using (at most) a few more megabytes of ram from the startup of the game, rather than from the first appearance of a SceneScope - since ReflexSettings is now loaded into memory more quickly.

I am not aware of any possible situation in which this would result in the breaking of anyone's Reflex-based project or even its tests.

The performance improvement persists even when ReflexSettings are marked as a preloaded resource, and the first SceneScope is present in the first scene.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've implemented this myself in my reflex-based project. It improved total initialization time from app launch to user interaction by (at most) about 200ms (admittedly, our usecase is pretty heavy and the device in question was a low-end tablet).
 
**Test Configuration**:
Tested in editor and in builds on various android and iOS mobile devices, as well as various PCs across mac, linux and windows OSes. No devices experienced a regression, although the noted benefits were pretty variable.  

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have checked that Reflex.GettingStarted still runs nicely
