### PR TITLE
Catch exceptions on disposing DisposableCollection

### DIFF
--- a/Assets/Reflex/Generics/DisposableCollection.cs
+++ b/Assets/Reflex/Generics/DisposableCollection.cs
@@ -21,10 +21,24 @@ namespace Reflex.Generics
         }
 
         public void Dispose()
-        {
+        {    
+            List<Exception> exceptions = null;
             while (_stack.TryPop(out var disposable))
             {
-                disposable.Dispose();
+                try
+                {
+                    disposable.Dispose();
+                }
+                catch (Exception e)
+                {
+                    exceptions ??= new();
+                    exceptions.Add(e);
+                }
+            }
+
+            if (exceptions is not null)
+            {
+                throw new AggregateException(exceptions);
             }
         }
     }


### PR DESCRIPTION
## Description

Added try-catch for Dispose calls

Fixes #107

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran PlayMode- and EditMode- tests

**Test Configuration**:
* Firmware version: Unity 6000.0.34f1
* Hardware: M4 Pro

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have checked that Reflex.GettingStarted still runs nicely
