### PR TITLE
Add DisableAutoDispose() to opt out of automatic IDisposable handling

### DIFF
--- a/Assets/Reflex.EditModeTests/DisposeTests.cs
+++ b/Assets/Reflex.EditModeTests/DisposeTests.cs
@@ -87,5 +87,63 @@ namespace Reflex.EditModeTests
             container.Dispose();
             service.Disposed.Should().Be(1);
         }
+
+        [Test]
+        public void DisableAutoDispose_ShouldPreventResolvedSingletonsFromBeingDisposed()
+        {
+            var container = new ContainerBuilder()
+                .DisableAutoDispose()
+                .RegisterType(typeof(Service), Lifetime.Singleton, Resolution.Lazy)
+                .Build();
+
+            var service = container.Single<Service>();
+            container.Dispose();
+
+            service.Disposed.Should().Be(0);
+        }
+
+        [Test]
+        public void DisableAutoDispose_ShouldPreventResolvedTransientsFromBeingDisposed()
+        {
+            var container = new ContainerBuilder()
+                .DisableAutoDispose()
+                .RegisterType(typeof(Service), Lifetime.Transient, Resolution.Lazy)
+                .Build();
+
+            var service = container.Single<Service>();
+            container.Dispose();
+
+            service.Disposed.Should().Be(0);
+        }
+
+        [Test]
+        public void DisableAutoDispose_ShouldPreventRegisteredValuesFromBeingDisposed()
+        {
+            var service = new Service();
+            var container = new ContainerBuilder()
+                .DisableAutoDispose()
+                .RegisterValue(service)
+                .Build();
+
+            container.Dispose();
+
+            service.Disposed.Should().Be(0);
+        }
+
+        [Test]
+        public void DisableAutoDispose_ShouldPreventFactoryProducedSingletonsFromBeingDisposed()
+        {
+            Service Factory(Container _) => new Service();
+
+            var container = new ContainerBuilder()
+                .DisableAutoDispose()
+                .RegisterFactory(Factory, Lifetime.Singleton, Resolution.Lazy)
+                .Build();
+
+            var service = container.Single<Service>();
+            container.Dispose();
+
+            service.Disposed.Should().Be(0);
+        }
     }
 }

--- a/Assets/Reflex/Core/ContainerBuilder.cs
+++ b/Assets/Reflex/Core/ContainerBuilder.cs
@@ -12,12 +12,13 @@ namespace Reflex.Core
     {
         public string Name { get; private set; }
         public Container Parent { get; private set; }
+        public bool AutoDisposeEnabled { get; private set; } = true;
         public List<Binding> Bindings { get; } = new();
         public event Action<Container> OnContainerBuilt;
 
         public Container Build()
         {
-            var disposables = new DisposableCollection();
+            var disposables = new DisposableCollection(AutoDisposeEnabled);
             var resolversByContract = new Dictionary<Type, List<IResolver>>();
 
             // Inherited resolvers
@@ -94,6 +95,12 @@ namespace Reflex.Core
         public ContainerBuilder SetParent(Container parent)
         {
             Parent = parent;
+            return this;
+        }
+
+        public ContainerBuilder DisableAutoDispose()
+        {
+            AutoDisposeEnabled = false;
             return this;
         }
         

--- a/Assets/Reflex/Generics/DisposableCollection.cs
+++ b/Assets/Reflex/Generics/DisposableCollection.cs
@@ -6,14 +6,30 @@ namespace Reflex.Generics
     internal sealed class DisposableCollection : IDisposable
     {
         private readonly Stack<IDisposable> _stack = new();
+        private readonly bool _autoDisposeEnabled;
+
+        public DisposableCollection(bool autoDisposeEnabled = true)
+        {
+            _autoDisposeEnabled = autoDisposeEnabled;
+        }
 
         public void Add(IDisposable disposable)
         {
+            if (!_autoDisposeEnabled)
+            {
+                return;
+            }
+
             _stack.Push(disposable);
         }
 
         public void TryAdd(object obj)
         {
+            if (!_autoDisposeEnabled)
+            {
+                return;
+            }
+
             if (obj is IDisposable disposable)
             {
                 _stack.Push(disposable);


### PR DESCRIPTION
## Description

Adds an opt-in `ContainerBuilder.DisableAutoDispose()` builder method. When set, the resulting container will not register resolved instances or registered values for automatic disposal.

Reflex's automatic `IDisposable` handling uses a fixed reverse-construction order (LIFO over a single stack). For projects that want to drive their own ordered shutdown sequence based on other criteria (eg. dependency-aware ordering, explicit attributes, etc.) the auto-dispose pass becomes a problem.  Also, some projects need Dispose to happen earlier than it does for Container (eg. before scene unloads, since some dispose logic needs valid access to objects in unity scene.)

For these reasons this setting is extremely useful

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Ran via Unity Test Runner.  All tests passed (though GarbageCollectionTests were skipped since it was run in debug)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [ ] I have checked that Reflex.GettingStarted still runs nicely