### PR TITLE
Add Container.OnDisposing event for ordered teardown

### DIFF
--- a/Assets/Reflex.EditModeTests/DisposeTests.cs
+++ b/Assets/Reflex.EditModeTests/DisposeTests.cs
@@ -87,5 +87,40 @@ namespace Reflex.EditModeTests
             container.Dispose();
             service.Disposed.Should().Be(1);
         }
+
+        [Test]
+        public void OnDisposing_ShouldFire_BeforeRegisteredDisposablesAreDisposed()
+        {
+            var service = new Service();
+            var observedDisposedAtEvent = -1;
+
+            var container = new ContainerBuilder()
+                .RegisterValue(service)
+                .Build();
+
+            container.OnDisposing += _ => observedDisposedAtEvent = service.Disposed;
+            container.Dispose();
+
+            observedDisposedAtEvent.Should().Be(0);
+            service.Disposed.Should().Be(1);
+        }
+
+        [Test]
+        public void OnDisposing_ShouldFire_BeforeChildContainersAreDisposed()
+        {
+            var parentEventOrder = -1;
+            var childDisposeOrder = -1;
+            var counter = 0;
+
+            var parent = new ContainerBuilder().Build();
+            var child = parent.Scope();
+            child.OnDisposing += _ => childDisposeOrder = ++counter;
+            parent.OnDisposing += _ => parentEventOrder = ++counter;
+
+            parent.Dispose();
+
+            parentEventOrder.Should().Be(1);
+            childDisposeOrder.Should().Be(2);
+        }
     }
 }

--- a/Assets/Reflex/Core/Container.cs
+++ b/Assets/Reflex/Core/Container.cs
@@ -15,6 +15,7 @@ namespace Reflex.Core
         public static Container RootContainer { get; internal set; }
         public string Name { get; }
         public Container Parent { get; }
+        public event Action<Container> OnDisposing;
         internal List<Container> Children { get; } = new();
         internal Dictionary<Type, List<IResolver>> ResolversByContract { get; }
         internal DisposableCollection Disposables { get; }
@@ -52,6 +53,8 @@ namespace Reflex.Core
 
         public void Dispose()
         {
+            OnDisposing?.Invoke(this);
+
             foreach (var child in Children.Reversed())
             {
                 child.Dispose();


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a `public event Action<Container> OnDisposing` to `Container`. It fires at the very top of `Container.Dispose()` — before children are disposed and before the auto-dispose pass over registered `IDisposable` instances.

Today, `Container.Dispose()` runs in a fixed order: child containers in reverse, then resolved/registered `IDisposable` instances popped in reverse-construction order. There is no extension point for application code to coordinate its own shutdown sequence before this happens.

A single event on `Container`, fired as the first line of `Dispose()`. Subscribers can run their own ordered shutdown logic against still-live dependencies, then let the standard teardown proceed.

Also, when combined with #146, allows for complete customization of dispose order


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Ran via Unity Test Runner.  All tests passed (though GarbageCollectionTests were skipped since it was run in debug)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [ ] I have checked that Reflex.GettingStarted still runs nicely
