### PR TITLE
 Reversed the display order of elements in the debug window

### DIFF
--- a/Assets/Reflex/Editor/DebuggingWindow/ReflexDebuggerWindow.cs
+++ b/Assets/Reflex/Editor/DebuggingWindow/ReflexDebuggerWindow.cs
@@ -155,6 +155,11 @@ namespace Reflex.Editor.DebuggingWindow
             var containerTreeElement = new MyTreeElement(container.Name, parent.Depth + 1, ++_id, ContainerIcon, () => string.Empty, Array.Empty<string>(), string.Empty, container.GetDebugProperties().BuildCallsite, kind: string.Empty);
             parent.Children.Add(containerTreeElement);
             containerTreeElement.Parent = parent;
+
+            foreach (var scopedContainer in container.Children)
+            {
+                BuildDataRecursively(containerTreeElement, scopedContainer);
+            }
             
             foreach (var pair in BuildMatrix(container))
             {
@@ -188,11 +193,6 @@ namespace Reflex.Editor.DebuggingWindow
                 }
                 
                 resolverTreeElement.SetParent(containerTreeElement);
-            }
-
-            foreach (var scopedContainer in container.Children)
-            {
-                BuildDataRecursively(containerTreeElement, scopedContainer);
             }
         }
         


### PR DESCRIPTION
## Description

As the number of registered objects increases, it can become difficult to find child containers. 

I changed the order because I thought that in such cases, the container is usually prioritized for debugging.

If you are planning a different approach regarding this, there is no need to merge it.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Unity 6000.5.1f1

Unity Test Runner. All tests passed (though GarbageCollectionTests were skipped since it was run in debug)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [ ] I have checked that Reflex.GettingStarted still runs nicely
